### PR TITLE
replace context.params.get('root') with context.obj.root

### DIFF
--- a/tutorbranding/plugin.py
+++ b/tutorbranding/plugin.py
@@ -133,7 +133,7 @@ hooks.Filters.ENV_PATTERNS_INCLUDE.add_item(r"theme/lms/static/sass/partials/lms
 @MFE_APPS.add()
 def _add_my_mfe(mfes):
     current_context = click.get_current_context()
-    root = current_context.params.get('root')
+    root = current_context.obj.root
     configuration = tutor_config.load(root)
 
     mfes.update(configuration['BRANDING_MFE'])


### PR DESCRIPTION
as per the latest fix for #3, the plugins crashed when enabling it because `context.params.get('root')` returns None. replacing this with context.obj.root seemed to work for me.